### PR TITLE
Add option parameter

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -37,15 +37,15 @@ get '/auth/:provider/callback' do
   pp result.credentials
   @twitter.access_token = result.credentials.token
   @twitter.access_token_secret = result.credentials.secret
-  result_fav = @twitter.favorites
+  result_fav = @twitter.favorites(count: '200')
   fav_tweets = []
 
   result_fav.each do |a|
-    fav_tweets.push(a.text)
-    puts a.text
+    fav_tweets.push(a.full_text)
   end
 
   erb "<a href='/'>Top</a><br>
        <h1>#{params[:provider]}</h1>
+       <h2>Your fav count number: #{fav_tweets.count}</h2>
        <pre>#{JSON.pretty_generate(fav_tweets)}</pre>"
 end

--- a/app.rb
+++ b/app.rb
@@ -19,7 +19,7 @@ end
 
 use Rack::Session::Cookie
 use OmniAuth::Builder do
-  provider :twitter, YOUR_CONSUMER_KEY, YOUR_CONSUMER_SECRET
+  provider :twitter, ENV.fetch('YOUR_CONSUMER_KEY'), ENV.fetch('YOUR_CONSUMER_SECRET')
 end
 
 get '/' do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
-version: '2'
+version: "2"
 services:
-  mysql:
+  favsearch:
+    container_name: "favseach"
     build: .
     volumes:
       - ./:/app
     ports:
-      - '4567:4567'
+      - "4567:4567"


### PR DESCRIPTION
Twitter API can get favorite records limited 200 with `count` parameter. (default: 20)
If it gets over 200 records, necessary to request with combined `max_id` and `since_id`.

close: #4 

